### PR TITLE
Initial testing

### DIFF
--- a/UntappdMenuDotNet.UnitTest/MenuTests.cs
+++ b/UntappdMenuDotNet.UnitTest/MenuTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UntappdMenuDotNet.UnitTest
+{
+    [TestClass]
+    public class MenuTests
+    {
+        private string email = "validemail@domain.com";
+        private string token = "validtoken";
+
+        [ExpectedException(typeof(ArgumentNullException), "An ArgumentNullException was expected but one was not thrown")]
+        [TestMethod]
+        public void NoAuthBytes()
+        {
+            _ = new UntappdService(null);
+        }
+
+        [ExpectedException(typeof(ArgumentNullException), "An ArgumentNullException was expected but one was not thrown")]
+        [TestMethod]
+        public void NoAuthStrings()
+        {
+            _ = new UntappdService(null, null);
+        }
+
+        [ExpectedException(typeof(UntappdException), "An UntappdException was expected but one was not thrown")]
+        [TestMethod]
+        public async Task MalformedAuthBytes()
+        {
+            var service = new UntappdService(new byte[] { 1, 2, 3 });
+            _ = await service.GetLocationCollection();
+        }
+
+        [ExpectedException(typeof(UntappdException),"An UntappdException was expected but one was not thrown")]
+        [TestMethod]
+        public async Task MalformedAuthStrings()
+        {
+            var service = new UntappdService("fake@nothing.net", "incorrect");
+            _ = await service.GetLocationCollection();
+        }
+
+        [TestMethod]
+        public async Task Locations()
+        {
+            var service = new UntappdService(email, token);
+            var locationCollection = await service.GetLocationCollection();
+            Assert.IsNotNull(locationCollection);
+            Assert.IsNotNull(locationCollection.Locations);
+        }
+    }
+}

--- a/UntappdMenuDotNet.UnitTest/Properties/AssemblyInfo.cs
+++ b/UntappdMenuDotNet.UnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("UntappdMenuDotNet.UnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UntappdMenuDotNet.UnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("ad84e1ba-f5e3-45c1-835a-e0836585253b")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/UntappdMenuDotNet.UnitTest/UntappdMenuDotNet.UnitTest.csproj
+++ b/UntappdMenuDotNet.UnitTest/UntappdMenuDotNet.UnitTest.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AD84E1BA-F5E3-45C1-835A-E0836585253B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UntappdMenuDotNet.UnitTest</RootNamespace>
+    <AssemblyName>UntappdMenuDotNet.UnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MenuTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UntappdMenuDotNet\UntappdMenuDotNet.csproj">
+      <Project>{988f0bc9-80a9-4bf6-a9ef-3944c62de3e3}</Project>
+      <Name>UntappdMenuDotNet</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/UntappdMenuDotNet.UnitTest/packages.config
+++ b/UntappdMenuDotNet.UnitTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net462" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net462" />
+</packages>

--- a/UntappdMenuDotNet.sln
+++ b/UntappdMenuDotNet.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UntappdMenuDotNet", "UntappdMenuDotNet\UntappdMenuDotNet.csproj", "{988F0BC9-80A9-4BF6-A9EF-3944C62DE3E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UntappdMenuDotNet.UnitTest", "UntappdMenuDotNet.UnitTest\UntappdMenuDotNet.UnitTest.csproj", "{AD84E1BA-F5E3-45C1-835A-E0836585253B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{988F0BC9-80A9-4BF6-A9EF-3944C62DE3E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{988F0BC9-80A9-4BF6-A9EF-3944C62DE3E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{988F0BC9-80A9-4BF6-A9EF-3944C62DE3E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD84E1BA-F5E3-45C1-835A-E0836585253B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD84E1BA-F5E3-45C1-835A-E0836585253B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD84E1BA-F5E3-45C1-835A-E0836585253B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD84E1BA-F5E3-45C1-835A-E0836585253B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UntappdMenuDotNet/LocationViewModel.cs
+++ b/UntappdMenuDotNet/LocationViewModel.cs
@@ -4,14 +4,20 @@ using System.Collections.Generic;
 
 namespace UntappdMenuDotNet
 {
-
-    public partial class UntappdLocation
+    [Obsolete("Deprecated in favor of UntappdLocationCollection", true)]
+    public class UntappdLocation
     {
         [JsonProperty("locations")]
         public List<UntappdLocationElement> Locations { get; set; }
     }
 
-    public partial class UntappdLocationElement
+    public class UntappdLocationCollection
+    {
+        [JsonProperty("locations")]
+        public List<UntappdLocationElement> Locations { get; set; }
+    }
+
+    public class UntappdLocationElement
     {
         [JsonProperty("id")]
         public long? Id { get; set; }
@@ -181,7 +187,7 @@ namespace UntappdMenuDotNet
         public UntappdMenuAnnouncements UntappdMenuAnnouncements { get; set; }
     }
 
-    public partial class UntappdHour
+    public class UntappdHour
     {
         [JsonProperty("id")]
         public long? Id { get; set; }

--- a/UntappdMenuDotNet/MenuAnnouncementsViewModel.cs
+++ b/UntappdMenuDotNet/MenuAnnouncementsViewModel.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace UntappdMenuDotNet
 {
-    public partial class UntappdMenuAnnouncements
+    public class UntappdMenuAnnouncements
     {
         [JsonProperty("current")]
         public UntappdAnnoucement[] Current { get; set; }
@@ -15,7 +15,7 @@ namespace UntappdMenuDotNet
         public UntappdAnnoucement[] Weekly { get; set; }
     }
 
-    public partial class UntappdAnnoucement
+    public class UntappdAnnoucement
     {
         [JsonProperty("id")]
         public long? Id { get; set; }

--- a/UntappdMenuDotNet/MenuItemContainerViewModel.cs
+++ b/UntappdMenuDotNet/MenuItemContainerViewModel.cs
@@ -3,12 +3,12 @@ using System;
 
 namespace UntappdMenuDotNet
 {
-    public partial class UntappdMenuItemContainers
+    public class UntappdMenuItemContainers
     {
         [JsonProperty("containers")]
         public UntappdMenuItemContainer[] Containers { get; set; }
     }
-    public partial class UntappdMenuItemContainer
+    public class UntappdMenuItemContainer
     {
         [JsonProperty("id")]
         public long Id { get; set; }
@@ -38,7 +38,7 @@ namespace UntappdMenuDotNet
         public long TrackBy { get; set; }
     }
 
-    public partial class UntappdMenuItemContainerSize
+    public class UntappdMenuItemContainerSize
     {
         [JsonProperty("id")]
         public long Id { get; set; }

--- a/UntappdMenuDotNet/MenuItemsViewModel.cs
+++ b/UntappdMenuDotNet/MenuItemsViewModel.cs
@@ -3,13 +3,13 @@ using System;
 
 namespace UntappdMenuDotNet
 {
-    public partial class UntappdMenuItems
+    public class UntappdMenuItems
     {
         [JsonProperty("items")]
         public UntappdMenuItem[] Items { get; set; }
     }
 
-    public partial class UntappdMenuItem
+    public class UntappdMenuItem
     {
         [JsonProperty("id")]
         public long? Id { get; set; }

--- a/UntappdMenuDotNet/MenuViewModel.cs
+++ b/UntappdMenuDotNet/MenuViewModel.cs
@@ -4,13 +4,13 @@ using System.Collections.Generic;
 
 namespace UntappdMenuDotNet
 {
-    public partial class UntappdMenus
+    public class UntappdMenus
     {
         [JsonProperty("menus")]
         public UntappdMenu[] Menus { get; set; }
     }
 
-    public partial class UntappdMenu
+    public class UntappdMenu
     {
         [JsonProperty("id")]
         public long? Id { get; set; }

--- a/UntappdMenuDotNet/UntappdException.cs
+++ b/UntappdMenuDotNet/UntappdException.cs
@@ -1,0 +1,47 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace UntappdMenuDotNet
+{
+    public class UntappdException : Exception
+    {
+        public UntappdException()
+        {
+        }
+
+        public UntappdException(string message) : base(message)
+        {
+        }
+
+        public UntappdException(string message, UntappdError untappdError) : base(message)
+        {
+            UntappdError = untappdError;
+        }
+
+        public UntappdException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        public UntappdException(string message, Exception inner, UntappdError untappdError) : base(message, inner)
+        {
+            UntappdError = untappdError;
+        }
+
+        public UntappdError UntappdError { get; private set; }
+    }
+
+    public class UntappdError
+    {
+        [JsonProperty("status")]
+        public long Status { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("detail")]
+        public string Detail { get; set; }
+
+        [JsonProperty("code")]
+        public string Code { get; set; }
+    }
+}

--- a/UntappdMenuDotNet/UntappdMenuDotNet.csproj
+++ b/UntappdMenuDotNet/UntappdMenuDotNet.csproj
@@ -48,13 +48,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LocationViewModel.cs" />
-    <Compile Include="MenuAnnoucementsViewModel.cs" />
+    <Compile Include="MenuAnnouncementsViewModel.cs" />
     <Compile Include="MenuItemContainerViewModel.cs" />
     <Compile Include="MenuItemsViewModel.cs" />
     <Compile Include="MenuSectionsViewModel.cs" />
     <Compile Include="MenuViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Service.cs" />
+    <Compile Include="UntappdException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- Added a basic unit test currently centered around authorization.
- In API calls, if a response is not success, an specific error is thrown using data from their content response
- Changed deserialized classes so they are not partials
- Made UntappdLocation obsolete and created new class UntappdLocationCollection instead (it was odd to have a Location have Locations?)
- Made the API wrapper service class have a single HttpClient per MS recommendations - also set the auth on it once in constructor
- Made the Get<T> generic to commonize logic

Could still use probably an overall try/catch on the Get for when the internet fails - also probably important that callers now know that exceptions can be expected.